### PR TITLE
Update python-telegram-bot version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-dotenv==0.15.0
-python-telegram-bot==10.1.0
+python-telegram-bot==13.5


### PR DESCRIPTION
Rodei no ZorinOS o bot do jeito que está, instalando as dependências do arquivo txt, porém ele abriu mas não funcionou, não respondeu mensagem alguma via telegram.
Já no sistema onde rodo meu bot do telegram, o bot http-cats funcionou perfeitamente com a versão 13.5 do python-telegram-bot

